### PR TITLE
Async removing dictionary/map approach fix

### DIFF
--- a/SDK/backendlessAPI/Classes/Persistence/MapDrivenDataStore.m
+++ b/SDK/backendlessAPI/Classes/Persistence/MapDrivenDataStore.m
@@ -224,7 +224,9 @@ static NSString *_SERVER_PERSISTENCE_SERVICE_PATH = @"com.backendless.services.p
 }
 
 -(void)remove:(NSDictionary<NSString*,id> *)entity response:(void(^)(NSNumber *))responseBlock error:(void(^)(Fault *))errorBlock {
-    [self remove:entity responder:[ResponderBlocksContext responderBlocksContext:responseBlock error:errorBlock]];
+    Responder *chainedResponder = [ResponderBlocksContext responderBlocksContext:responseBlock error:errorBlock];
+    NSArray *args = @[_tableName, entity];
+    [invoker invokeAsync:_SERVER_PERSISTENCE_SERVICE_PATH method:@"remove" args:args responder:chainedResponder];
 }
 
 -(void)find:(void(^)(NSArray *))responseBlock error:(void(^)(Fault *))errorBlock {


### PR DESCRIPTION
-(void)remove:(NSDictionary<NSString*,id> *)entity response:(void(^)(NSNumber *))responseBlock error:(void(^)(Fault *))errorBlock {} method from MapDrivenDataStore class crashed on saving. Fixed.